### PR TITLE
Cleanup and bash-ify .bashrc

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -5,36 +5,34 @@
 # If not running interactively, don't do anything
 [[ $- != *i* ]] && return
 
-# git stuff
-if [ -f "/etc/arch-release" ]; then
-    . /usr/share/git/completion/git-completion.bash
-    . /usr/share/git/completion/git-prompt.sh
-elif [ -f "/etc/bash_completion" ]; then
-    . /etc/bash_completion
-fi
-
-# gcloud
-if [ -f "/opt/google-cloud-sdk/path.bash.inc" ]; then
-    . /opt/google-cloud-sdk/path.bash.inc
-fi
-
-if [ -f "/opt/google-cloud-sdk/completion.bash.inc" ]; then
-    . /opt/google-cloud-sdk/completion.bash.inc
-fi
+possibly_included_files=(
+	# git stuff
+	/usr/share/git/completion/git-completion.bash
+	/usr/share/git/completion/git-prompt.sh
+	/etc/bash_completion
+	# gcloud
+	/opt/google-cloud-sdk/path.bash.inc
+	/opt/google-cloud-sdk/completion.bash.inc
+)
+for f in "${possibly_included_files[@]}"; do
+	[[ -f $f ]] && source "$f"
+done
+unset possibly_included_files f
 
 # aliases
 alias ls='ls --color=auto'
 
 # aliases with args (functions)
-vimglob() { vim $(find . | grep $1); }
+vimglob() ( shopt -s globstar nullglob; exec vim **/*"$*"*; )
 
 # prompt
 PS1='[\u@\h \W$(__git_ps1 " (%s)")]\$ '
 
-if [ -x "/usr/bin/vim" ]; then
+# editor
+if [[ -x /usr/bin/vim ]]; then
     export EDITOR=/usr/bin/vim
     export VISUAL="$EDITOR"
 fi
 
 # env vars
-export PATH="$PATH:$HOME/bin"
+export PATH="$HOME/bin:$PATH"


### PR DESCRIPTION
The sourcing logic can be unified, and using an explicit `source` rather
than a `.` is more clear.

As well, vimglob can be implemented using pure bash, which performs
better and is less error prone, considering the current lack of quoting.
We implement the function with a subshell ( ) instead of a grouping { }
so that the shopt change doesn't affect our current context, and then we
exec vim instead of the ordinary invocation, so that despite the
subshell, we don't actually incur two forks, so the cost is the same
between subshell and grouping.

The [[ ]] operator in bash automatically quotes one operand, so we use
that instead.

The PATH addition now prefers an explicit $HOME to ~, and it also
prioritizes utilities in $HOME/bin over system ones.

(This commit is untested.)